### PR TITLE
export QueueLike

### DIFF
--- a/src/Control/Concurrent/Supervisor/Types.hs
+++ b/src/Control/Concurrent/Supervisor/Types.hs
@@ -13,6 +13,7 @@
 module Control.Concurrent.Supervisor.Types
   ( SupervisorSpec0
   , Supervisor0
+  , QueueLike(..)
   , Child_
   , DeadLetter
   , RestartAction


### PR DESCRIPTION
QueueLike is currently not exported. That means that it doesn't show up in the documentation, and it is not possible to actually read from the event queue.
