### PR TITLE
upgrade to LTS 5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.7
+resolver: lts-5.1
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -84,9 +84,9 @@ qToList q = do
     Nothing -> return []
 
 --------------------------------------------------------------------------------
-assertContainsNMsg :: (SupervisionEvent -> Bool) 
+assertContainsNMsg :: (SupervisionEvent -> Bool)
                    -> Int
-                   -> [SupervisionEvent] 
+                   -> [SupervisionEvent]
                    -> IO ()
 assertContainsNMsg _ 0 _ = HUnit.assertBool "" True
 assertContainsNMsg _ x [] = do
@@ -120,7 +120,7 @@ assertContainsNLimitReached = assertContainsNMsg matches
 assertContainsRestartMsg :: [SupervisionEvent] -> ThreadId -> IOProperty ()
 assertContainsRestartMsg [] _ = QM.assert False
 assertContainsRestartMsg (x:xs) tid = case x of
-  ((ChildRestarted old _ _ _)) -> 
+  ((ChildRestarted old _ _ _)) ->
     if old == tid then QM.assert True else assertContainsRestartMsg xs tid
   _ -> assertContainsRestartMsg xs tid
 
@@ -153,7 +153,7 @@ fromAction :: Supervisor -> ThreadAction -> IO ThreadId
 fromAction s Live = forkSupervised s oneForOne (forever $ threadDelay 100000000)
 fromAction s (DieAfter (TTL ttl)) = forkSupervised s oneForOne (threadDelay ttl)
 fromAction s (ThrowAfter (TTL ttl)) = forkSupervised s oneForOne (do
-  threadDelay ttl 
+  threadDelay ttl
   throwIO $ AssertionFailed "die")
 
 --------------------------------------------------------------------------------
@@ -200,7 +200,7 @@ testTooManyRestarts :: Assertion
 testTooManyRestarts = do
   supSpec <- newSupervisorSpec
   sup <- newSupervisor supSpec
-  _ <- forkSupervised sup (OneForOne 0 $ limitRetries 5) $ error "die"
+  _ <- forkSupervised sup (OneForOne defaultRetryStatus $ limitRetries 5) $ error "die"
   threadDelay 2000000
   q <- qToList (eventStream sup)
   assertContainsNLimitReached 1 q

--- a/test/Tests/Bounded.hs
+++ b/test/Tests/Bounded.hs
@@ -84,9 +84,9 @@ qToList q = do
     Nothing -> return []
 
 --------------------------------------------------------------------------------
-assertContainsNMsg :: (SupervisionEvent -> Bool) 
+assertContainsNMsg :: (SupervisionEvent -> Bool)
                    -> Int
-                   -> [SupervisionEvent] 
+                   -> [SupervisionEvent]
                    -> IO ()
 assertContainsNMsg _ 0 _ = HUnit.assertBool "" True
 assertContainsNMsg _ x [] = do
@@ -120,7 +120,7 @@ assertContainsNLimitReached = assertContainsNMsg matches
 assertContainsRestartMsg :: [SupervisionEvent] -> ThreadId -> IOProperty ()
 assertContainsRestartMsg [] _ = QM.assert False
 assertContainsRestartMsg (x:xs) tid = case x of
-  ((ChildRestarted old _ _ _)) -> 
+  ((ChildRestarted old _ _ _)) ->
     if old == tid then QM.assert True else assertContainsRestartMsg xs tid
   _ -> assertContainsRestartMsg xs tid
 
@@ -200,7 +200,7 @@ testTooManyRestarts :: Assertion
 testTooManyRestarts = do
   supSpec <- newSupervisorSpec
   sup <- newSupervisor supSpec
-  _ <- forkSupervised sup (OneForOne 0 $ limitRetries 5) $ error "die"
+  _ <- forkSupervised sup (OneForOne defaultRetryStatus $ limitRetries 5) $ error "die"
   threadDelay 2000000
   q <- qToList (eventStream sup)
   assertContainsNLimitReached 1 q

--- a/threads-supervisor.cabal
+++ b/threads-supervisor.cabal
@@ -27,7 +27,7 @@ library
   build-depends:
     base                 >= 4.6 && < 6,
     unordered-containers >= 0.2.0.0 && < 0.5.0.0,
-    retry                >= 0.5 && < 0.10,
+    retry                >= 0.7 && < 0.10,
     stm                  >= 2.4,
     time                 >= 1.2
   hs-source-dirs: src


### PR DESCRIPTION
Upgrades to Stackage LTS 5.

More specifically, migrates from retry 0.6.x to 0.7.x, which changed `Int` to `RetryStatus`. Since the `OneForOne` constructor is exposed, this will be a breaking change for this library.
