### PR TITLE
Initial, tentative support for 1.1.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 before_install:
   - mkdir -p ~/.local/bin
   - export PATH=~/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.2/stack-1.0.2-x86_64-linux.tar.gz | tar xz --strip-components=1 -C ~/.local/bin
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.2/stack-1.0.2-linux-x86_64.tar.gz | tar xz --strip-components=1 -C ~/.local/bin
   - chmod a+x ~/.local/bin/stack
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: haskell
 
 sudo: false
 
+env:
+  - GHCVER=7.10.2 STACK_YAML=stack.yaml
 
 notifications:
   email: false
@@ -13,12 +15,16 @@ cache:
 before_install:
   - mkdir -p ~/.local/bin
   - export PATH=~/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.5.0/stack-0.1.5.0-x86_64-linux.tar.gz | tar xz --strip-components=1 -C ~/.local/bin
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.2/stack-1.0.2-x86_64-linux.tar.gz | tar xz --strip-components=1 -C ~/.local/bin
   - chmod a+x ~/.local/bin/stack
 
 install:
- - stack setup --no-terminal
- - stack build --only-snapshot --no-terminal
+  - stack setup --no-terminal
+  - stack build --only-snapshot --no-terminal
 
 script:
- - stack --no-terminal test
+  - stack --no-terminal test --coverage
+
+after_script:
+  - travis_retry curl -L https://github.com/rubik/stack-hpc-coveralls/releases/download/v0.0.3.0/shc-linux-x64-$GHCVER.tar.bz2 | tar -xj
+  - ./shc threads-supervisor threads-supervisor-tests

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This library implement a simple, IO-based, forkIO-friendly library for Erlang-st
 
 # Changelog
 
+* 1.1.0.0
+    - (**Breaking Change**) Support lts-5.1 and retry-0.7 (https://github.com/adinapoli/threads-supervisor/pull/9)
+
 * 1.0.4.1
     - Export QueueLike (https://github.com/adinapoli/threads-supervisor/pull/8)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
-[![Build Status](https://travis-ci.org/adinapoli/threads-supervisor.svg?branch=master)](https://travis-ci.org/adinapoli/threads-supervisor)
+<h1 align="center">
+    <a href="https://github.com/adinapoli/threads-supervisor">
+        Threads Supervisor
+    </a>
+</h1>
 
-# Threads-Supervisor
+<p align="center">
+    <a href="https://travis-ci.org/adinapoli/threads-supervisor">
+        <img alt="Tests"
+             src="https://img.shields.io/travis/adinapoli/threads-supervisor.svg?style=flat-square">
+    </a>
+    <a href="https://coveralls.io/github/adinapoli/threads-supervisor">
+        <img alt="Code coverage"
+             src="https://img.shields.io/coveralls/adinapoli/threads-supervisor.svg?style=flat-square">
+    </a>
+    <a href="https://hackage.haskell.org/package/threads-supervisor">
+        <img alt="Version"
+             src="https://img.shields.io/hackage/v/threads-supervisor.svg?label=version&amp;style=flat-square">
+    </a>
+</p>
 
-This library implement a simple, IO-based, forkIO-friendly library for Erlang-style thread supervision.
+<p align="center">
+    Simple, IO-based, forkIO-friendly threads supervision library.
+</p>
+
+<hr>
 
 # Changelog
 

--- a/threads-supervisor.cabal
+++ b/threads-supervisor.cabal
@@ -1,5 +1,5 @@
 name:                threads-supervisor
-version:             1.0.4.1
+version:             1.1.0.0
 synopsis:            Simple, IO-based library for Erlang-style thread supervision
 description:         Simple, IO-based library for Erlang-style thread supervision
 license:             MIT


### PR DESCRIPTION
Test coverage is provided by:

https://github.com/rubik/stack-hpc-coveralls

Unfortunately my coveralls is acting stupid and couldn't find `threads-supervisor` in the list of my repo. go figure..
