### PR TITLE
Add epoch to letters and children

### DIFF
--- a/src/Control/Concurrent/Supervisor.hs
+++ b/src/Control/Concurrent/Supervisor.hs
@@ -27,4 +27,4 @@ type Child = Types.Child_ TQueue
 --------------------------------------------------------------------------------
 -- NOTE: The `maxBound` value will be ignore by the underlying implementation.
 newSupervisor :: RestartStrategy -> IO Supervisor
-newSupervisor str = Types.newSupervisor str maxBound 
+newSupervisor str = Types.newSupervisor str maxBound

--- a/src/Control/Concurrent/Supervisor/Types.hs
+++ b/src/Control/Concurrent/Supervisor/Types.hs
@@ -50,7 +50,6 @@ import qualified Data.HashMap.Strict as Map
 import           Data.IORef
 import           Data.Time
 import           Data.Time.Clock.POSIX
-import           Data.Typeable
 
 --------------------------------------------------------------------------------
 type Mailbox = TChan DeadLetter
@@ -90,26 +89,26 @@ instance QueueLike TBQueue where
     unless isFull $ writeTBQueue q e
 
 --------------------------------------------------------------------------------
-data DeadLetter = DeadLetter !Epoch !ThreadId !SomeException
+data DeadLetter = DeadLetter !LetterEpoch !ThreadId !SomeException
 
+--------------------------------------------------------------------------------
 type Epoch = POSIXTime
+newtype LetterEpoch = LetterEpoch Epoch deriving Show
+newtype ChildEpoch  = ChildEpoch  Epoch deriving Show
 
 --------------------------------------------------------------------------------
 data RestartResult =
-    Restarted
+    Restarted !ThreadId !ThreadId !RetryStatus !UTCTime
     -- ^ The supervised `Child_` was restarted successfully.
-  | RestartLimitReached
-    -- ^ The `Child_` was restarted too many times and the limit was reached.
-  | ChildNotFound
-    -- ^ The `Child_` couldn't be found in the Supervisor's map.
-  | StaleDeadLetter
+  | StaleDeadLetter !ThreadId !LetterEpoch !ChildEpoch !UTCTime
     -- ^ A stale `DeadLetter` was received.
-  | RestartFailed SomeException
-    -- ^ The restart failed for a reason decribed by `SomeException`
+  | RestartFailed SupervisionEvent
+    -- ^ The restart failed for a reason decribed by a `SupervisionEvent`
+  deriving Show
 
 --------------------------------------------------------------------------------
-data Child_ q = Worker !Epoch !RetryStatus (RetryPolicyM IO) RestartAction
-              | Supvsr !Epoch !RetryStatus (RetryPolicyM IO) !(Supervisor q)
+data Child_ q = Worker !ChildEpoch !RetryStatus (RetryPolicyM IO) RestartAction
+              | Supvsr !ChildEpoch !RetryStatus (RetryPolicyM IO) !(Supervisor q)
 
 --------------------------------------------------------------------------------
 type RestartAction = ThreadId -> IO ThreadId
@@ -119,6 +118,8 @@ data SupervisionEvent =
      ChildBorn !ThreadId !UTCTime
    | ChildDied !ThreadId !SomeException !UTCTime
    | ChildRestarted !ThreadId !ThreadId !RetryStatus !UTCTime
+   | ChildNotFound  !ThreadId !UTCTime
+   | StaleDeadLetterReceived  !ThreadId !LetterEpoch !ChildEpoch !UTCTime
    | ChildRestartLimitReached !ThreadId !RetryStatus !UTCTime
    | ChildFinished !ThreadId !UTCTime
    deriving Show
@@ -146,7 +147,7 @@ tryNotifyParent mbPMbox myId ex = do
     Nothing -> return ()
     Just m' -> do
       e <- getEpoch
-      atomically $ writeTChan m' (DeadLetter e myId ex)
+      atomically $ writeTChan m' (DeadLetter (LetterEpoch e) myId ex)
 
 -- $new
 -- In order to create a new supervisor, you need a `SupervisorSpec`,
@@ -235,7 +236,7 @@ forkSupervised :: QueueLike q
 forkSupervised sup@Supervisor{..} policy act =
   bracket (supervised sup act) return $ \newChild -> do
     e <- getEpoch
-    let ch = Worker e defaultRetryStatus policy (const (supervised sup act))
+    let ch = Worker (ChildEpoch e) defaultRetryStatus policy (const (supervised sup act))
     atomicModifyIORef' (_sc_children _sp_ctx) $ \chMap -> (Map.insert newChild ch chMap, ())
     now <- getCurrentTime
     atomically $ writeQueue (_sc_eventStream _sp_ctx) (ChildBorn newChild now)
@@ -246,7 +247,7 @@ supervised :: QueueLike q => Supervisor q -> IO () -> IO ThreadId
 supervised Supervisor{..} act = forkFinally act $ \res -> case res of
   Left ex -> bracket myThreadId return $ \myId -> do
     e <- getEpoch
-    atomically $ writeTChan (_sc_mailbox _sp_ctx) (DeadLetter e myId ex)
+    atomically $ writeTChan (_sc_mailbox _sp_ctx) (DeadLetter (LetterEpoch e) myId ex)
   Right _ -> bracket myThreadId return $ \myId -> do
     now <- getCurrentTime
     atomicModifyIORef' (_sc_children _sp_ctx) $ \chMap -> (Map.delete myId chMap, ())
@@ -256,63 +257,68 @@ supervised Supervisor{..} act = forkFinally act $ \res -> case res of
 -- | Ignore any stale `DeadLetter`, which is a `DeadLetter` with an `Epoch`
 -- smaller than the one stored in the `Child_` to restart. Such stale `DeadLetter`
 -- are simply ignored.
-ignoringStaleLetters :: Epoch -> Epoch -> IO RestartResult -> IO RestartResult
-ignoringStaleLetters deadLetterEpoch childEpoch act = do
-  if deadLetterEpoch < childEpoch then return StaleDeadLetter else act
+ignoringStaleLetters :: ThreadId
+                     -> LetterEpoch
+                     -> ChildEpoch
+                     -> IO RestartResult
+                     -> IO RestartResult
+ignoringStaleLetters tid deadLetterEpoch@(LetterEpoch l) childEpoch@(ChildEpoch c) act = do
+  now <- getCurrentTime
+  if l < c then return (StaleDeadLetter tid deadLetterEpoch childEpoch now) else act
 
 --------------------------------------------------------------------------------
 restartChild :: QueueLike q
              => SupervisionCtx q
-             -> Epoch
+             -> LetterEpoch
              -> UTCTime
              -> ThreadId
              -> IO RestartResult
 restartChild ctx deadLetterEpoch now newDeath = do
   chMap <- readIORef (_sc_children ctx)
   case Map.lookup newDeath chMap of
-    Nothing -> return ChildNotFound
-    Just (Worker workerEpoch rState rPolicy act) -> ignoringStaleLetters deadLetterEpoch workerEpoch $ do
+    Nothing -> return $ RestartFailed (ChildNotFound newDeath now)
+    Just (Worker workerEpoch rState rPolicy act) -> ignoringStaleLetters newDeath deadLetterEpoch workerEpoch $ do
       runRetryPolicy rState rPolicy emitEventChildRestartLimitReached $ \newRState -> do
         e <- getEpoch
-        let ch = Worker e newRState rPolicy act
+        let ch = Worker (ChildEpoch e) newRState rPolicy act
         newThreadId <- act newDeath
         writeIORef (_sc_children ctx) (Map.insert newThreadId ch $! Map.delete newDeath chMap)
         emitEventChildRestarted newThreadId newRState
     Just (Supvsr supervisorEpoch rState rPolicy (Supervisor deathSup ctx')) -> do
-      ignoringStaleLetters deadLetterEpoch supervisorEpoch $ do
+      ignoringStaleLetters newDeath deadLetterEpoch supervisorEpoch $ do
         runRetryPolicy rState rPolicy emitEventChildRestartLimitReached $ \newRState -> do
           e <- getEpoch
           restartedSup <- newSupervisor (_sc_strategy ctx) (_sc_eventStreamSize ctx')
-          let ch = (Supvsr e newRState rPolicy restartedSup)
+          let ch = Supvsr (ChildEpoch e) newRState rPolicy restartedSup
           -- TODO: shutdown children?
           let newThreadId = _sp_myTid restartedSup
           writeIORef (_sc_children ctx) (Map.insert newThreadId ch $! Map.delete deathSup chMap)
           emitEventChildRestarted newThreadId newRState
   where
-    emitEventChildRestarted newThreadId newRState = atomically $
-      writeQueue (_sc_eventStream ctx) (ChildRestarted newDeath newThreadId newRState now)
-    emitEventChildRestartLimitReached newRState = atomically $
-      writeQueue (_sc_eventStream ctx) (ChildRestartLimitReached newDeath newRState now)
+    emitEventChildRestarted newThreadId newRState = do
+      return $ Restarted newDeath newThreadId newRState now
+    emitEventChildRestartLimitReached newRState = do
+      return $ RestartFailed (ChildRestartLimitReached newDeath newRState now)
     runRetryPolicy :: RetryStatus
                    -> RetryPolicyM IO
-                   -> (RetryStatus -> IO ())
-                   -> (RetryStatus -> IO ())
+                   -> (RetryStatus -> IO RestartResult)
+                   -> (RetryStatus -> IO RestartResult)
                    -> IO RestartResult
     runRetryPolicy rState rPolicy ifAbort ifThrottle = do
      maybeDelay <- getRetryPolicyM rPolicy rState
      case maybeDelay of
-       Nothing -> ifAbort rState >> return RestartLimitReached
+       Nothing -> ifAbort rState
        Just delay ->
          let newRState = rState { rsIterNumber = rsIterNumber rState + 1
                                 , rsCumulativeDelay = rsCumulativeDelay rState + delay
                                 , rsPreviousDelay = Just (maybe 0 (const delay) (rsPreviousDelay rState))
                                 }
-         in threadDelay delay >> ifThrottle newRState >> return Restarted
+         in threadDelay delay >> ifThrottle newRState
 
 --------------------------------------------------------------------------------
 restartOneForOne :: QueueLike q
                  => SupervisionCtx q
-                 -> Epoch
+                 -> LetterEpoch
                  -> UTCTime
                  -> ThreadId
                  -> IO RestartResult
@@ -325,16 +331,24 @@ handleEvents ctx@SupervisionCtx{..} = do
   now <- getCurrentTime
   atomically $ writeQueue _sc_eventStream (ChildDied newDeath ex now)
   -- If we catch an `AsyncException`, we have nothing but good
-  -- reasons not to restart the thread.
-  -- Note to the skeptical: It's perfectly fine do put `undefined` here,
-  -- as `typeOf` does not inspect the content (try in GHCi!)
-  case typeOf ex == (typeOf (undefined :: AsyncException)) of
-    True -> handleEvents ctx
-    False -> do
-      _ <- case _sc_strategy of
+  -- reasons NOT to restart the thread.
+  case asyncExceptionFromException ex of
+    Just (_ :: AsyncException) -> do
+      -- Remove the `Child_` from the map, log what happenend.
+      atomicModifyIORef' _sc_children $ \chMap -> (Map.delete newDeath chMap, ())
+      atomically $ writeQueue _sc_eventStream (ChildDied newDeath ex now)
+      handleEvents ctx
+    Nothing -> do
+      restartResult <- case _sc_strategy of
         OneForOne -> restartOneForOne ctx epoch now newDeath
-      -- TODO: shutdown supervisor? Handle the `RestartResult` cases
-      -- appropriately.
+      -- TODO: shutdown supervisor?
+      atomically $ case restartResult of
+        StaleDeadLetter tid le we tm -> do
+          writeQueue _sc_eventStream (StaleDeadLetterReceived tid le we tm)
+        RestartFailed reason -> do
+          writeQueue _sc_eventStream reason
+        Restarted oldId newId rStatus tm ->
+          writeQueue _sc_eventStream (ChildRestarted oldId newId rStatus tm)
       handleEvents ctx
 
 -- $monitor
@@ -364,7 +378,7 @@ monitorWith policy sup1 sup2 = do
     Nothing -> do
       e <- getEpoch
       let sup2RetryStatus = defaultRetryStatus
-      let ch' = Supvsr e sup2RetryStatus policy sup2
+      let ch' = Supvsr (ChildEpoch e) sup2RetryStatus policy sup2
       atomicModifyIORef' sup1Children $ \chMap -> (Map.insert sup2Id ch' chMap, ())
       duped <- atomically $ dupTChan sup1Mailbox
       atomicModifyIORef' sup2ParentMailbox $ const (Just duped, ())

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,6 +25,7 @@ allTests :: TestTree
 allTests = testGroup "All Tests" [
     withQuickCheckDepth "Control.Concurrent.Supervisor" 20 [
         testProperty "1 supervised thread, no exceptions" (monadicIO test1SupThreadNoEx)
+      , testProperty "1 supervised thread, premature async exception" (monadicIO test1SupThreadPrematureAsyncDemise)
       , testProperty "1 supervised thread, premature exception" (monadicIO test1SupThreadPrematureDemise)
       , testProperty "1 supervised supervisor, premature exception" (monadicIO test1SupSpvrPrematureDemise)
       , testProperty "killing spree" (monadicIO testKillingSpree)

--- a/threads-supervisor.cabal
+++ b/threads-supervisor.cabal
@@ -28,6 +28,7 @@ library
     base                 >= 4.6 && < 6,
     unordered-containers >= 0.2.0.0 && < 0.5.0.0,
     retry                >= 0.7 && < 0.10,
+    transformers         >= 0.4 && < 0.5,
     stm                  >= 2.4,
     time                 >= 1.2
   hs-source-dirs: src

--- a/threads-supervisor.cabal
+++ b/threads-supervisor.cabal
@@ -1,5 +1,5 @@
 name:                threads-supervisor
-version:             1.2.0.0
+version:             1.2.0.1
 synopsis:            Simple, IO-based library for Erlang-style thread supervision
 description:         Simple, IO-based library for Erlang-style thread supervision
 license:             MIT


### PR DESCRIPTION
cc @srijs 

As I'm on Easter holidays over here, I spent 2 hours of hacking time doing 2 things:
1. Adding the concept of "epochs" as you suggested, so that we can ignore stale `DeadLetter`s. I have also cleaned up the `restartChild` section, got rid of the yielded `Bool` in favour of a more richer data structure `RestartResult` and finally moved emitting the events down to `handleEvents`, it seems just much cleaner.
2. I fixed a bug in `handleEvent` where my `typeOf` check was never firing. The subtleties was that what we had as input of `typeOf` was `SomeException` thus that check was **always** yielding `False` regardless which kind of `Exception` we had as input. Yikes!
