### PR TITLE
fix: make epochs monotonic

### DIFF
--- a/src/Control/Concurrent/Supervisor/Types.hs
+++ b/src/Control/Concurrent/Supervisor/Types.hs
@@ -49,7 +49,7 @@ import           Control.Retry
 import qualified Data.HashMap.Strict as Map
 import           Data.IORef
 import           Data.Time
-import           Data.Time.Clock.POSIX
+import           System.Clock (Clock(Monotonic), TimeSpec, getTime)
 
 --------------------------------------------------------------------------------
 type Mailbox = TChan DeadLetter
@@ -92,7 +92,7 @@ instance QueueLike TBQueue where
 data DeadLetter = DeadLetter !LetterEpoch !ThreadId !SomeException
 
 --------------------------------------------------------------------------------
-type Epoch = POSIXTime
+type Epoch = TimeSpec
 newtype LetterEpoch = LetterEpoch Epoch deriving Show
 newtype ChildEpoch  = ChildEpoch  Epoch deriving Show
 
@@ -138,7 +138,7 @@ fibonacciRetryPolicy = fibonacciBackoff 100
 
 --------------------------------------------------------------------------------
 getEpoch :: MonadIO m => m Epoch
-getEpoch = liftIO getPOSIXTime
+getEpoch = liftIO $ getTime Monotonic
 
 --------------------------------------------------------------------------------
 tryNotifyParent :: IORef (Maybe Mailbox) -> ThreadId -> SomeException -> IO ()

--- a/threads-supervisor.cabal
+++ b/threads-supervisor.cabal
@@ -26,6 +26,7 @@ library
     Control.Concurrent.Supervisor.Tutorial
   build-depends:
     base                 >= 4.6 && < 6,
+    clock                >= 0.6,
     unordered-containers >= 0.2.0.0 && < 0.5.0.0,
     retry                >= 0.7 && < 0.10,
     transformers         >= 0.4 && < 0.5,


### PR DESCRIPTION
There is a number of problems with using POSIX time for the epochs, the biggest one being that it is subject to leap seconds and other time adjustments, which might make time either "stand still" or even go backwards. The usual solution to this problem is to use what is called a monotonic clock. A monotonic clock does not provide an absolute point in time, but rather the time difference to a single local event (such as system start-up). By doing that, it can guarantee that time only ever progresses forward, and does so linearly.

This is quite an important property for the epochs, since a wrong time measurement could have us take into account expired dead letters, or possibly even worse, discard perfectly fine dead letters.

It does not quite solve everything, for example there is still a theoretical scenario where two dead letters happen within the same nanosecond, but it should improve things to the point where a failure is very unlikely.

The optimal solution would be to introduce a global counter that is incremented on every measurement of time (i.e. a logical, not a physical clock), to not only guarantee monotonicity, but in fact strict monotonicity, so that no two events could ever have the same epoch.
