### PR TITLE
Allow transformers-0.6

### DIFF
--- a/threads-supervisor.cabal
+++ b/threads-supervisor.cabal
@@ -29,7 +29,7 @@ library
     clock                >= 0.6,
     unordered-containers >= 0.2.0.0 && < 0.5.0.0,
     retry                >= 0.7 && < 0.10,
-    transformers         >= 0.4 && < 0.6,
+    transformers         >= 0.4 && < 0.7,
     stm                  >= 2.5,
     time                 >= 1.2
   hs-source-dirs: src


### PR DESCRIPTION
Tested using `cabal test --constraint='transformers>=0.6' -w ghc-9.2.2`